### PR TITLE
Make port number configurable

### DIFF
--- a/lib/fake_http/server.ex
+++ b/lib/fake_http/server.ex
@@ -22,6 +22,13 @@ defmodule FakeHTTP.Server do
 
   @type headers :: [{binary, binary}] | %{binary => binary}
 
+  def child_spec(init_arg) do
+    # Because multiple server processes are required for the same test,
+    # we override the default `id` with a reference.
+    super(init_arg)
+    |> Supervisor.child_spec(id: make_ref())
+  end
+
   @spec start_link(options) :: on_start
   def start_link(opts \\ []) do
     unique_key = make_ref()

--- a/test/fake_http/server_test.exs
+++ b/test/fake_http/server_test.exs
@@ -17,13 +17,16 @@ defmodule FakeHTTP.ServerTest do
     end
 
     test "given port number" do
+      # Take an available port
       {:ok, socket} = :gen_tcp.listen(0, [:inet])
-      {:ok, port} = :inet.port(socket) |> IO.inspect
+      {:ok, port} = :inet.port(socket)
 
       :ok = :gen_tcp.close(socket)
-      Process.sleep(100)
 
-      start_supervised!(Server, port: port)
+      # Start a server
+      server = start_supervised!({Server, [port: port]})
+      assert base_url = Server.base_url(server)
+      assert base_url =~ ~r":#{port}"
     end
   end
 

--- a/test/fake_http/server_test.exs
+++ b/test/fake_http/server_test.exs
@@ -15,6 +15,16 @@ defmodule FakeHTTP.ServerTest do
       assert server
       assert Process.alive?(server)
     end
+
+    test "given port number" do
+      {:ok, socket} = :gen_tcp.listen(0, [:inet])
+      {:ok, port} = :inet.port(socket) |> IO.inspect
+
+      :ok = :gen_tcp.close(socket)
+      Process.sleep(100)
+
+      start_supervised!(Server, port: port)
+    end
   end
 
   describe "stop" do


### PR DESCRIPTION
The port number of HTTP server should be configurable by user. Sometimes we have to configure FakeHTTP.Server before any tests started.

- [x] Add `port` option
- [x] Add tests